### PR TITLE
Updated the starting event to check if the ContentFinder already exists.

### DIFF
--- a/source/Simple301/Core/RedirectApplicationEvents.cs
+++ b/source/Simple301/Core/RedirectApplicationEvents.cs
@@ -23,7 +23,10 @@ namespace Simple301.Core
         /// </summary>
         protected override void ApplicationStarting(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
         {
-            ContentFinderResolver.Current.InsertType<RedirectContentFinder>(0);
+            if (!ContentFinderResolver.Current.ContainsType(typeof(RedirectContentFinder)))
+            {
+                ContentFinderResolver.Current.InsertType<RedirectContentFinder>(0);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
In some cases, especially when doing multilingual projects, content finders exist in a specific order on the site, so we want to incorporate this one very specifically.

The DLLs don't always get loaded in the correct order, which means that it can add the type twice and throw an error. This PR does a check to see if the type already exists, and if so, ignores the Simple 301's addition of it to avoid duplication :)